### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
 setting.py
+# Created by https://www.gitignore.io/api/django
+
+### Django ###
+*.log
+*.pot
+*.pyc
+__pycache__/
+local_settings.py
+db.sqlite3
+media
+
+# If your build process includes running collectstatic, then you probably don't need or want to include staticfiles/
+# in your Git repository. Update and uncomment the following line accordingly.
+# <django-project-name>/staticfiles/
+
+# End of https://www.gitignore.io/api/django


### PR DESCRIPTION

que ha cambiado?
le agregamos al gitignore soporte para node
- [ ] frontend
- [ ] backend
- [x] server

# como puedo probar los cambios?
por ejemplos los archivos y la carpeta node_modules ya no se suben al repo ver el archivo .gitignore completo
